### PR TITLE
add random note option

### DIFF
--- a/settings.ts
+++ b/settings.ts
@@ -23,6 +23,7 @@ export class DefaultNewTabPageSettingTab extends PluginSettingTab {
 				.addOption("daily-notes", "Daily Note") // except for the new tab page, the values should be equal to the command-id to run
 				.addOption("switcher:open", "Quick Switcher (Core Plugin)")
 				.addOption("obsidian-another-quick-switcher:search-command_recent-search", "Another Quick Switcher")
+				.addOption("random-note", "Random Note")
 				.setValue(this.plugin.settings.whatToOpen)
 				.onChange(async (value) => {
 					this.plugin.settings.whatToOpen = value;


### PR DESCRIPTION
## Description of the Change
Adds an option the the settings to have the new tab open to a random note.

## Checklist
- [ x] Used the provided eslint configuration, [as explained in the Readme](README.md#Contribute).
- [ x] Did *not* use prettier.
- [ x] Used expressive variable names.

