### PR TITLE
fix: adds checking for empty state after a minor delay

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -64,10 +64,21 @@ export class DefaultNewTabPageSettingTab extends PluginSettingTab {
 				})
 				.setValue(this.plugin.settings.mode)
 					.onChange(async (value) => {
-					this.plugin.settings.mode = value;
-					await this.plugin.saveSettings();
-				});
+						this.plugin.settings.mode = value;
+						await this.plugin.saveSettings();
+					});
 			});
 
+		new Setting(this.containerEl)
+			.setName("Compatability mode")
+			.setDesc("Enable compatability mode for other plugins (e.g. Obsidian Projects) which open new tabs. This introduces minor delays.")
+			.addToggle((toggle) => {
+			  toggle
+				 .setValue(this.plugin.settings.compatibilityMode)
+				 .onChange(async (value) => {
+					this.plugin.settings.compatibilityMode = value;
+					await this.plugin.saveSettings();
+				})
+			});
 	}
 }


### PR DESCRIPTION
## Description of the Change
The previous proposed fix to ensure compatibility with other plugins didn't work.

It seems that other plugins will open a leaf and only after that change the view state. The layout-change listener in this code is run before the state is changed. Thus, it couldn't understand that other plugins had the intention of changing the state – and thus open a new tab, preventing the other plugin from opening the correct view.

To fix this, I added a new check to see if the leaf view state is still empty before opening the `whatToOpen` file in the new leaf. This inevitably had to be done at the next tick for otherwise the view state is always empty. To make sure that not all users experience an unnecessary delay I've added a compatibility mode setting, false by default, which toggles this check.

Bug report: https://github.com/chrisgrieser/new-tab-default-page/issues/14

## Checklist
- [x] Used the provided eslint configuration, [as explained in the Readme](README.md#Contribute).
- [x] Did *not* use prettier.
- [x] Used expressive variable names.
- [x] Code is commented well.
